### PR TITLE
Add productName

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "debug",
     "profile"
   ],
+  "productName": "DeNode",
   "author": "steelbrain",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
So it no longer says "Electron" in the OSX top bar.
